### PR TITLE
Implement active ability source checking methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.java]
+ij_java_doc_do_not_wrap_if_one_line = true

--- a/src/main/java/io/github/ladysnake/pal/AbilitySource.java
+++ b/src/main/java/io/github/ladysnake/pal/AbilitySource.java
@@ -128,11 +128,11 @@ public final class AbilitySource implements Comparable<AbilitySource> {
      *
      * <p>At most one {@code AbilitySource} can return {@code true} for a given player and ability.
      * When more than one source is granting the same ability, the one considered active is the highest
-     * one according to {@link #compareTo(AbilitySource)}.
+     * one according to {@link #compareTo(AbilitySource)}. This means that an {@code AbilitySource} with
+     * a higher {@linkplain #getPriority() priority} is more likely to be considered "active".
      *
      * <p>This method can be used to check if side effects should trigger for a specific ability source,
-     * e.g. to avoid wasting jetpack fuel when multiple sources are giving flight at the same time,
-     * or to avoid showing concurrent animations.
+     * e.g. to avoid wasting jetpack fuel when multiple sources are giving flight at the same time.
      *
      * @param player  the player to check on
      * @param ability an ability that may be granted by this source
@@ -148,7 +148,8 @@ public final class AbilitySource implements Comparable<AbilitySource> {
      * Compares two ability sources.
      *
      * <p>The comparison is based on the assigned {@linkplain #getPriority() priority},
-     * with ties being resolved arbitrarily.
+     * with ties being resolved arbitrarily. Priorities are compared using their natural ordering,
+     * meaning a higher priority causes the source to be considered higher.
      *
      * @param o the source to be compared.
      * @return the value {@code 0} if the argument source is equal to

--- a/src/main/java/io/github/ladysnake/pal/AbilitySource.java
+++ b/src/main/java/io/github/ladysnake/pal/AbilitySource.java
@@ -19,6 +19,7 @@ package io.github.ladysnake.pal;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A source for a {@link PlayerAbility}.
@@ -32,14 +33,55 @@ import net.minecraft.util.Identifier;
  * {@link Pal#getAbilitySource(Identifier)} or {@link Pal#getAbilitySource(String, String)}.
  * Instances obtained that way are safe to compare by identity.
  */
-public final class AbilitySource {
+public final class AbilitySource implements Comparable<AbilitySource> {
+    /** A standard priority for ability sources that are free to use (e.g. active potion effects) */
+    public static final int FREE = 2000;
+    /** A standard priority for ability sources that cost some renewable resource to use (e.g. stamina) */
+    public static final int RENEWABLE = 1000;
+    /** The default priority for ability sources */
+    public static final int DEFAULT = 0;
+    /** A standard priority for ability sources that cost some non-renewable resource to use (e.g. item fuel) */
+    public static final int CONSUMABLE = -1000;
+
     private final Identifier id;
+    private final int priority;
 
     /**
+     * @see Pal#getAbilitySource(String, String)
      * @see Pal#getAbilitySource(Identifier)
+     * @see Pal#getAbilitySource(Identifier, int)
      */
-    AbilitySource(Identifier id) {
+    AbilitySource(Identifier id, int priority) {
         this.id = id;
+        this.priority = priority;
+    }
+
+    /**
+     * Returns the identifier used to create this {@code AbilitySource}.
+     *
+     * <p> The returned identifier is unique and can be passed to {@link Pal#getAbilitySource(Identifier)}
+     * to retrieve this instance.
+     *
+     * @return the identifier wrapped by this {@code AbilitySource}
+     */
+    public Identifier getId() {
+        return this.id;
+    }
+
+    /**
+     * Returns the priority used to create this {@code AbilitySource}.
+     *
+     * <p>If no priority was specified during registration, the {@linkplain #DEFAULT default priority} is used.
+     *
+     * @return the priority assigned to this {@code AbilitySource}
+     * @see Pal#getAbilitySource(Identifier, int)
+     * @see #FREE
+     * @see #RENEWABLE
+     * @see #DEFAULT
+     * @see #CONSUMABLE
+     */
+    public int getPriority() {
+        return priority;
     }
 
     /**
@@ -72,7 +114,7 @@ public final class AbilitySource {
      * Returns {@code true} if this ability source is currently granting {@code player}
      * the given {@code ability}.
      *
-     * @param player the player to check on
+     * @param player  the player to check on
      * @param ability an ability that may be granted by this source
      * @return {@code true} if this grants {@code player} the {@code ability}
      */
@@ -81,20 +123,51 @@ public final class AbilitySource {
     }
 
     /**
-     * Returns the identifier used to create this {@code AbilitySource}.
+     * Returns {@code true} if this ability source is the one actively granting {@code ability}
+     * to {@code player}.
      *
-     * <p> The returned identifier is unique and can be passed to {@link Pal#getAbilitySource(Identifier)}
-     * to retrieve this instance.
+     * <p>At most one {@code AbilitySource} can return {@code true} for a given player and ability.
+     * When more than one source is granting the same ability, the one considered active is the highest
+     * one according to {@link #compareTo(AbilitySource)}.
      *
-     * @return the identifier wrapped by this {@code AbilitySource}
+     * <p>This method can be used to check if side effects should trigger for a specific ability source,
+     * e.g. to avoid wasting jetpack fuel when multiple sources are giving flight at the same time,
+     * or to avoid showing concurrent animations.
+     *
+     * @param player  the player to check on
+     * @param ability an ability that may be granted by this source
+     * @return {@code true} if this ability source is the one actively granting {@code ability}
+     * to {@code player}, {@code false} otherwise.
+     * @since 1.4.0
      */
-    public Identifier getId() {
-        return this.id;
+    public boolean isActivelyGranting(PlayerEntity player, PlayerAbility ability) {
+        return ability.getTracker(player).getActiveSource() == this;
+    }
+
+    /**
+     * Compares two ability sources.
+     *
+     * <p>The comparison is based on the assigned {@linkplain #getPriority() priority},
+     * with ties being resolved arbitrarily.
+     *
+     * @param o the source to be compared.
+     * @return the value {@code 0} if the argument source is equal to
+     * this source; a value less than {@code 0} if this source
+     * is considered less than the source argument; and a
+     * value greater than {@code 0} if this source is
+     * considered greater than the string argument.
+     * @implNote the current way to resolve ties is through identifier comparison.
+     * @since 1.4.0
+     */
+    @Override
+    public int compareTo(@NotNull AbilitySource o) {
+        int priorityOrder = Integer.compare(this.priority, o.priority);
+        return priorityOrder != 0 ? priorityOrder : this.id.compareTo(o.id);
     }
 
     @Override
     public String toString() {
-        return "AbilitySource@" + this.id;
+        return "AbilitySource@" + this.id + "+" + this.priority;
     }
 
 }

--- a/src/main/java/io/github/ladysnake/pal/AbilityTracker.java
+++ b/src/main/java/io/github/ladysnake/pal/AbilityTracker.java
@@ -21,6 +21,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A tracker for a player ability that can be turned on or off.
@@ -64,15 +65,19 @@ public interface AbilityTracker {
     /**
      * Returns the ability source actively granting this tracker's ability.
      *
-     * <p>The active source is the one with the highest priority among the sources
-     * currently granting this tracker's ability.
+     * <p>The active source is the one considered highest among the sources currently granting this tracker's ability,
+     * according to {@link AbilitySource#compareTo(AbilitySource)}.
+     * This means that an {@code AbilitySource} with
+     * a higher {@linkplain AbilitySource#getPriority() priority} is more likely to be considered "active".
+     * .
      *
      * @return the active source, or {@code null} if no source is granting the ability
      * @see Pal#getAbilitySource(Identifier, int)
      * @see AbilitySource#isActivelyGranting(PlayerEntity, PlayerAbility)
+     * @see AbilitySource#compareTo(AbilitySource)
      * @since 1.4.0
      */
-    AbilitySource getActiveSource();
+    @Nullable AbilitySource getActiveSource();
 
     /**
      * Returns {@code true} if this tracker's ability is currently enabled.

--- a/src/main/java/io/github/ladysnake/pal/AbilityTracker.java
+++ b/src/main/java/io/github/ladysnake/pal/AbilityTracker.java
@@ -17,7 +17,9 @@
  */
 package io.github.ladysnake.pal;
 
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
 
 /**
@@ -58,6 +60,19 @@ public interface AbilityTracker {
      */
     @Contract(pure = true)
     boolean isGrantedBy(AbilitySource abilitySource);
+
+    /**
+     * Returns the ability source actively granting this tracker's ability.
+     *
+     * <p>The active source is the one with the highest priority among the sources
+     * currently granting this tracker's ability.
+     *
+     * @return the active source, or {@code null} if no source is granting the ability
+     * @see Pal#getAbilitySource(Identifier, int)
+     * @see AbilitySource#isActivelyGranting(PlayerEntity, PlayerAbility)
+     * @since 1.4.0
+     */
+    AbilitySource getActiveSource();
 
     /**
      * Returns {@code true} if this tracker's ability is currently enabled.

--- a/src/main/java/io/github/ladysnake/pal/Pal.java
+++ b/src/main/java/io/github/ladysnake/pal/Pal.java
@@ -111,7 +111,7 @@ public final class Pal implements ModInitializer {
      *
      * <p>Calling this method multiple times with equivalent identifiers results
      * in a single instance being returned. More formally, for any two Identifiers
-     * {@code i1} and {@code i2}, {@code registerAbilitySource(i1) == registerAbilitySource(i2)}
+     * {@code i1} and {@code i2}, {@code getAbilitySource(i1) == getAbilitySource(i2)}
      * is true if and only if {@code i1.equals(i2)}.
      *
      * @param abilitySourceId a unique identifier for the ability source
@@ -127,12 +127,12 @@ public final class Pal implements ModInitializer {
      *
      * <p>Calling this method multiple times with equivalent identifiers results
      * in a single instance being returned. More formally, for any two Identifiers
-     * {@code i1} and {@code i2}, {@code registerAbilitySource(i1) == registerAbilitySource(i2)}
+     * {@code i1} and {@code i2}, {@code getAbilitySource(i1) == getAbilitySource(i2)}
      * is true if and only if {@code i1.equals(i2)}.
      *
      * <p>The {@code priority} determines which source will show up as the {@linkplain AbilityTracker#getActiveSource() active one}
      * in the event multiple sources are granting the same ability. This can be used to e.g. avoid wasting fuel
-     * through multiple flight items, or only show one animation at a time.
+     * through multiple flight items.
      *
      * @param abilitySourceId a unique identifier for the ability source
      * @return an {@code AbilitySource} for {@code abilitySourceId}

--- a/src/main/java/io/github/ladysnake/pal/SimpleAbilityTracker.java
+++ b/src/main/java/io/github/ladysnake/pal/SimpleAbilityTracker.java
@@ -17,6 +17,7 @@
  */
 package io.github.ladysnake.pal;
 
+import io.github.ladysnake.pal.impl.PalInternals;
 import io.github.ladysnake.pal.impl.VanillaAbilityTracker;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.player.PlayerEntity;
@@ -25,8 +26,8 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
 import net.minecraft.util.Identifier;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * This class provides a basic implementation of the {@code AbilityTracker}
@@ -41,7 +42,7 @@ import java.util.Set;
  */
 public class SimpleAbilityTracker implements AbilityTracker {
     protected final PlayerEntity player;
-    protected final Set<AbilitySource> abilitySources = new HashSet<>();
+    protected final SortedSet<AbilitySource> abilitySources = new TreeSet<>();
     protected final PlayerAbility ability;
 
     public SimpleAbilityTracker(PlayerAbility ability, PlayerEntity player) {
@@ -71,6 +72,11 @@ public class SimpleAbilityTracker implements AbilityTracker {
     @Override
     public boolean isGrantedBy(AbilitySource abilitySource) {
         return this.abilitySources.contains(abilitySource);
+    }
+
+    @Override
+    public AbilitySource getActiveSource() {
+        return this.abilitySources.last();
     }
 
     @Override

--- a/src/testmod/resources/assets/paltest/models/item/wax_wings.json
+++ b/src/testmod/resources/assets/paltest/models/item/wax_wings.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "minecraft:item/phantom_membrane"
+  }
+}


### PR DESCRIPTION
A common behaviour when implementing modded ability sources is to play side effects like burning fuel while active. In current versions of PAL however, there is no way to determine which ability is the "primary/active" one, which means every source has to play those side effects simultaneously, leading to player annoyances like fuel waste.

This PR introduces the concept of active/primary ability source to help mods deal with this issue, backed by a priority-based source ordering system.