### PR TITLE
added call to original operation

### DIFF
--- a/src/testmod/java/io/github/ladysnake/paltest/mixin/LivingEntityMixin.java
+++ b/src/testmod/java/io/github/ladysnake/paltest/mixin/LivingEntityMixin.java
@@ -33,5 +33,6 @@ public class LivingEntityMixin {
         if (effect instanceof FlightEffect flightEffect) {
             flightEffect.onRemoved((LivingEntity) (Object) this);
         }
+        original.call(effect, attributeContainer);
     }
 }


### PR DESCRIPTION
The original onRemoved method must be called so that the LivingEntity class can handle the removal of attribute modifiers.

This mixin is given as an example in the main readme of the library but, as is, breaks the default behaviour of effects with modifiers such as minecraft:health_boost and minecraft:absorption.

This is my first PR ever. I hope this is proper etiquette 👋